### PR TITLE
new optional state to add AppArmor rules, refs #6

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -65,18 +65,38 @@ via include list.
 
 Configuration is splitted:
   * for connections:
-  
+
     * in a main file for default options and ``%default`` connection. This file include files from *dropin* directory
     * in a *dropin* directory where each connection has its own config file
   * for secrets:
-  
+
     * in a main file which include files from *dropin* directory
     * in a *dropin* directory where each connection has its own secret file
+
+**warning**: if you use AppArmor, you will need to add specific rules for read access to the *secrets* *dropin* directory.
+You can manage them on your own, or use the ``apparmor`` state, see below.
 
 ``strongswan.service``
 ^^^^^^^^^^^^^^^^^^^^^^
 
 This state manage the strongswan service.
+
+``strongswan.apparmor``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+**This state is not run by default with the meta-state**
+**It has only been tested on recent versions of Debian, feel free to propose a PR to add support for other distributions.**
+
+It configures AppArmor rules to allow read access to the *secrets* *dropin* directory.
+It must be run explicitely or use this pillar to activate it:
+
+.. code-block::
+
+    strongswan:
+      lookup:
+        apparmor:
+          add_rules: true
+
 
 Testing
 -------

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -66,12 +66,12 @@ via include list.
 Configuration is splitted:
   * for connections:
   
-    * in a main file for default options and `%default` connection. This file include files from 'dropin' directory
-    * in a 'dropin' directory where each connection has its own config file
+    * in a main file for default options and ``%default`` connection. This file include files from *dropin* directory
+    * in a *dropin* directory where each connection has its own config file
   * for secrets:
   
-    * in a main file which include files from 'dropin' directory
-    * in a 'dropin' directory where each connection has its own secret file
+    * in a main file which include files from *dropin* directory
+    * in a *dropin* directory where each connection has its own secret file
 
 ``strongswan.service``
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,8 @@
 strongswan:
   # override default core settings in lookup dict
   # lookup:
+  #   apparmor:
+  #     add_rules: false
 
   # default config
   config:

--- a/strongswan/apparmor.sls
+++ b/strongswan/apparmor.sls
@@ -1,0 +1,28 @@
+---
+# manage AppArmor rules for Strongswan
+# for the 'dropin' directories
+
+{%- set topdir = tpldir.split('/')[0] %}
+{%- from tpldir ~ "/map.jinja" import strongswan with context %}
+{%- from tpldir ~ "/libtofs.jinja" import files_switch with context %}
+
+apparmor_usr.lib.ipsec.charon:
+  file.managed:
+    - name: {{ strongswan.apparmor.rules_file }}
+    - source: {{ files_switch(['apparmor-usr.lib.ipsec.charon'],
+                              lookup='apparmor-ipsec-charon'
+                 )
+              }}
+    - user: root
+    - group: root
+    - mode: '0644'
+    - template: jinja
+    - context:
+        secrets_dir: {{ strongswan.config.dropin_secrets }}
+    - watch_in:
+      - service: apparmor_service
+
+apparmor_service:
+  service.running:
+    - reload: True
+    - name: apparmor

--- a/strongswan/apparmor.sls
+++ b/strongswan/apparmor.sls
@@ -6,7 +6,7 @@
 {%- from tpldir ~ "/map.jinja" import strongswan with context %}
 {%- from tpldir ~ "/libtofs.jinja" import files_switch with context %}
 
-apparmor_usr.lib.ipsec.charon:
+stronswan-apparmor-file-rules-ipsec-dropin:
   file.managed:
     - name: {{ strongswan.apparmor.rules_file }}
     - source: {{ files_switch(['apparmor-usr.lib.ipsec.charon'],
@@ -20,9 +20,9 @@ apparmor_usr.lib.ipsec.charon:
     - context:
         secrets_dir: {{ strongswan.config.dropin_secrets }}
     - watch_in:
-      - service: apparmor_service
+      - service: stronswan-apparmor-service-apparmor
 
-apparmor_service:
+stronswan-apparmor-service-apparmor:
   service.running:
     - reload: True
     - name: apparmor

--- a/strongswan/config.sls
+++ b/strongswan/config.sls
@@ -32,7 +32,7 @@ include:
   - .install
 
 # Global options
-ipsec-global-options:
+strongswan-config-file-global-options:
   file.managed:
     - name: {{ strongswan.config.global_options }}
     - source: {{ files_switch(['ipsec.conf.jinja'],
@@ -51,7 +51,7 @@ ipsec-global-options:
 
 # Connections
 {% if connections %}
-ipsec-dropin-options:
+strongswan-config-directory-ipsec-dropin-connections:
   file.directory:
     - name: {{ strongswan.config.dropin_options }}
     - user: root
@@ -61,7 +61,7 @@ ipsec-dropin-options:
 
 {% for connection, data in connections.items() %}
   {% set dropin_file = strongswan.config.dropin_options ~ '/' ~ connection ~ '.conf' %}
-ipsec-conn-{{ connection }}-config:
+strongswan-config-file-ipsec-conn-{{ connection }}:
   file.managed:
     - name: {{ dropin_file }}
     - source: {{ files_switch(['connection.conf.jinja'],
@@ -80,7 +80,7 @@ ipsec-conn-{{ connection }}-config:
 {% endfor %}
 
 # Global secrets
-ipsec-global-secrets:
+strongswan-config-file-ipsec-global-secrets:
   file.managed:
     - name: {{ strongswan.config.global_secrets }}
     - source: {{ files_switch(['ipsec.secrets.jinja'],
@@ -97,7 +97,7 @@ ipsec-global-secrets:
 
 # Secrets
 {% if secrets %}
-ipsec-dropin-secrets:
+strongswan-config-directory-ipsec-dropin-secrets:
   file.directory:
     - name: {{ strongswan.config.dropin_secrets }}
     - user: root
@@ -108,7 +108,7 @@ ipsec-dropin-secrets:
 
 {% for secret, data in secrets.items() %}
   {% set dropin_file = strongswan.config.dropin_secrets ~ '/' ~ secret ~ '.secrets' %}
-ipsec-secret-{{ secret }}-config:
+strongswan-config-file-ipsec-secret-{{ secret }}:
   file.managed:
     - name: {{ dropin_file }}
     - source: {{ files_switch(['secret.secrets.jinja'],

--- a/strongswan/defaults.yaml
+++ b/strongswan/defaults.yaml
@@ -2,6 +2,9 @@
 # vim: ft=yaml
 ---
 strongswan:
+  apparmor:
+    add_rules: false
+    rules_file: /etc/apparmor.d/local/usr.lib.ipsec.charon
   pkg: strongswan
   group: root
   config:

--- a/strongswan/files/default/apparmor-usr.lib.ipsec.charon
+++ b/strongswan/files/default/apparmor-usr.lib.ipsec.charon
@@ -1,0 +1,5 @@
+#########################################################
+# File managed by Salt. Changes risk being overwritten.
+#########################################################
+{{ secrets_dir }}/     r,
+{{ secrets_dir }}/**   r,

--- a/strongswan/init.sls
+++ b/strongswan/init.sls
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
+{%- set topdir = tpldir.split('/')[0] %}
+{%- from tpldir ~ "/map.jinja" import strongswan with context %}
+{%- from tpldir ~ "/libtofs.jinja" import files_switch with context %}
+
 include:
   - .install
+{%- if strongswan.apparmor.add_rules %}
+  - .apparmor
+{%- endif %}
   - .config
   - .service

--- a/strongswan/install.sls
+++ b/strongswan/install.sls
@@ -5,7 +5,7 @@
 
 {#- Simulating `grains.osfinger`, which is avoided since not available in all distros #}
 {%- if [grains.os, grains.osrelease] == ['Amazon', '2'] %}
-strongswan-epel-repo:
+strongswan-install-repo-epel:
   pkgrepo.managed:
     - name: epel
     - humanname: Extra Packages for Enterprise Linux 7 - $basearch
@@ -15,9 +15,9 @@ strongswan-epel-repo:
     - gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
     - failovermethod: priority
     - require_in:
-      - pkg: strongswan-pkg
+      - pkg: strongswan-install-package
 {%- endif %}
 
-strongswan-pkg:
+strongswan-install-package:
   pkg.installed:
     - name: {{ strongswan.pkg }}


### PR DESCRIPTION

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?

New feature

#### Primary type

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests

#6 



### Describe the changes you're proposing

New apparmor state, optional, to insert AppArmor rules to allow reading of the secrets dropin directory.
The state must be called directly or activated with a specific pillar.

This state has only been tested on Debian and may not be functional with other platforms without further work.

### Pillar / config required to test the proposed changes

```
strongswan:
 lookup:
   apparmor:
     add_rules: true
```



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
       ----------
                 ID: apparmor_usr.lib.ipsec.charon
           Function: file.managed
               Name: /etc/apparmor.d/local/usr.lib.ipsec.charon
             Result: True
            Comment: File /etc/apparmor.d/local/usr.lib.ipsec.charon updated
            Started: 12:22:55.046559
           Duration: 4.721 ms
            Changes:
              ----------
              diff:
                  New file
              mode:
                  0644
```


### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist

No test has been included because the state only works on Debian.
Testing would require creating a new test suite to only test this specific state on Debian

### Additional context

none


